### PR TITLE
Fix incorrect colors in SCSS file

### DIFF
--- a/styles/languages/sass.less
+++ b/styles/languages/sass.less
@@ -1,14 +1,26 @@
 // SASS
 
 .sass {
-  .at-rule {
+  .at-rule .at-rule {
     &,
-    > .punctuation {
+    > .punctuation{
       .uno-1();
     }
   }
-  .mixin > .variable,
-  .include > .variable {
+  .mixin + .function,
+  .include + .function {
     .duo-2();
+  }
+  &.property-value {
+    .duo-1();
+    .function {
+      .uno-2();
+    }
+    .punctuation {
+      .uno-4();
+    }
+  }
+  &.variable.parameter.url {
+    .duo-1();
   }
 }

--- a/styles/languages/scss.less
+++ b/styles/languages/scss.less
@@ -11,4 +11,16 @@
   .include + .function {
     .duo-2();
   }
+  &.property-value {
+    .duo-1();
+    .function {
+      .uno-2();
+    }
+    .punctuation {
+      .uno-4();
+    }
+  }
+  &.variable.parameter.url {
+    .duo-1();
+  }
 }


### PR DESCRIPTION
<img width="377" alt="screen shot 2016-01-14 at 20 30 39" src="https://cloud.githubusercontent.com/assets/1246672/12335127/e41763d8-bafd-11e5-8eff-24bf296f2a0e.png">

https://github.com/simurai/duotone-syntax/issues/9

Let me know what you think @simurai should fix all issues I encountered in SCSS.
