### PR TITLE
2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A double-hue syntax theme for Atom.
 
 ![duotone](https://cloud.githubusercontent.com/assets/378023/11769688/753483be-a230-11e5-9193-51db5e77ce6b.png)
 
-DuoTone themes use only 2 hues (7 shades in total). It __tones down__ less important parts (like punctuation and brackets) and highlights only the __important__ ones. This leads to a more calm color scheme, but still lets you find the stuff you're looking for.
+DuoTone themes use only 2 hues (8 shades in total). It __tones down__ less important parts (like punctuation and brackets) and highlights only the __important__ ones. This leads to a more calm color scheme, but still lets you find the stuff you're looking for.
 
 
 ## Language support

--- a/index.less
+++ b/index.less
@@ -3,4 +3,5 @@
 
 @import (reference) "styles/syntax-variables";
 @import 'styles/editor';
+@import 'styles/palette';
 @import 'styles/languages/_index';

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -13,6 +13,7 @@
 @uno-2: hsl(@syntax-uno, 66%, 80%);
 @uno-3: hsl(@syntax-uno, 22%, 60%);
 @uno-4: hsl(@syntax-uno, 10%, 44%);
+@uno-5: hsl(@syntax-uno, 10%, 33%);
 
 // Duo hue
 @duo-1: hsl(@syntax-duo, 99%, 77%);

--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -1,11 +1,11 @@
 // Language syntax highlighting
 
 // Mixins -----------------------------------
-.punctuation-mixin(@color:@uno-4) {
+.punctuation-mixin() {
   .punctuation,
   .bracket,
   .brace {
-    color: @color;
+    .uno-5();
   }
   .string .punctuation {
     .duo-3();
@@ -18,7 +18,7 @@
 // this basically matches everything without a specific scope
 // so we put it first
 .meta {
-  .uno-4();
+  .uno-5();
 }
 
 .html.elements,
@@ -28,16 +28,20 @@
   .uno-1();
 }
 
-.variable,
 .attribute-name,
 .character.escape {
-  .uno-2();
-}
-
-.support {
   .uno-3();
 }
 
+.support {
+  .uno-4();
+}
+
+// Uno hue -----------------------------------
+
+.variable {
+  .uno-3();
+}
 
 // Duo hue -----------------------------------
 .string,
@@ -58,7 +62,7 @@
 
 // Comments -----------------------------------
 .comment {
-  .uno-4();
+  .uno-5();
   font-style: italic;
 }
 

--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -1,15 +1,5 @@
 // Language syntax highlighting
 
-.uno-1 { color: @uno-1; } // .... Strong
-.uno-2 { color: @uno-2; } // ...   |
-.uno-3 { color: @uno-3; } // ..    v
-.uno-4 { color: @uno-4; } // .    Weak
-
-.duo-1 { color: @duo-1; } // .... Strong
-.duo-2 { color: @duo-2; } // ...   |
-.duo-3 { color: @duo-3; } // .    Weak
-
-
 // Mixins -----------------------------------
 .punctuation-mixin(@color:@uno-4) {
   .punctuation,

--- a/styles/languages/clojure.less
+++ b/styles/languages/clojure.less
@@ -2,13 +2,13 @@
   .expression {
     .duo-1();
     .punctuation {
-      .uno-4();
+      .uno-5();
     }
   }
   .symbol {
     .uno-2();
   }
   .vector {
-    .uno-3();
+    .uno-4();
   }
 }

--- a/styles/languages/coffee.less
+++ b/styles/languages/coffee.less
@@ -2,6 +2,6 @@
 
 .coffee {
   &.source {
-    .uno-3();
+    .uno-4();
   }
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,6 +1,6 @@
 .source.cs {
   .meta {
-    .uno-3();
+    .uno-4();
   }
   .method {
     .uno-2();

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -2,13 +2,7 @@
 
 .css {
   &.source {
-    .uno-4();
-  }
-  &.at-rule {
-    .uno-1();
-    .keyword.punctuation {
-      color: inherit;
-    }
+    .uno-5();
   }
   &.attribute-name {
     &.id,
@@ -17,4 +11,20 @@
       .uno-1();
     }
   }
+  &.unit {
+    .duo-2();
+  }
+  &.function {
+    .duo-3();
+  }
+  &.punctuation.terminator {
+    .duo-3();
+  }
+  &.at-rule {
+    .uno-1();
+    .keyword.punctuation {
+      color: inherit;
+    }
+  }
+
 }

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -14,7 +14,7 @@
     &.bold   { .bold(); }
     &.italic { .italic(); }
     &.strike {
-      .uno-4();
+      .uno-5();
       text-decoration: line-through;
     }
 
@@ -24,12 +24,12 @@
 
     &.raw .support,
     &.code .support {
-      .uno-4(); // Fenced code blocks
+      .uno-5(); // Fenced code blocks
     }
   }
 
   &.comment  {
-    .uno-4();
+    .uno-5();
     &.quote {
       .uno-2();
     }
@@ -40,7 +40,7 @@
 
     .border,
     .pipe {
-      .uno-4();
+      .uno-5();
     }
   }
 

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -2,10 +2,10 @@
 
 .html {
   &.meta {
-    .uno-4();
+    .uno-5();
   }
   &.text {
-    .uno-3();
+    .uno-4();
   }
   .string .id {
     .duo-1();

--- a/styles/languages/jade.less
+++ b/styles/languages/jade.less
@@ -2,7 +2,7 @@
 
 .jade {
   &.text {
-    .uno-3();
+    .uno-4();
   }
 
   .meta.control.flow {
@@ -10,7 +10,7 @@
   }
 
   .constant.name.attribute.tag {
-    .uno-4();
+    .uno-5();
   }
 
   .attribute-name.id {

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -4,7 +4,7 @@
     .punctuation-mixin();
   }
   .dereference {
-    .uno-4();
+    .uno-5();
 
   }
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -4,14 +4,14 @@
   .string {
     .uno-2();
     .punctuation {
-      .uno-4();
+      .uno-5();
     }
   }
   .value {
     & > .string {
       .duo-1();
       .punctuation {
-        .uno-4();
+        .uno-5();
       }
     }
     .constant {

--- a/styles/languages/less.less
+++ b/styles/languages/less.less
@@ -2,7 +2,7 @@
 
 .less {
   &.variable:first-child {
-    .uno-1(); // stronger variable color when declaring
+    .uno-2(); // stronger variable color when declaring
   }
   .mixin {
     .duo-2();

--- a/styles/languages/mediawiki.less
+++ b/styles/languages/mediawiki.less
@@ -19,6 +19,6 @@
   .pipe,
   .link,
   .tag {
-    .uno-4();
+    .uno-5();
   }
 }

--- a/styles/languages/sass.less
+++ b/styles/languages/sass.less
@@ -17,7 +17,7 @@
       .uno-2();
     }
     .punctuation {
-      .uno-4();
+      .uno-5();
     }
   }
   &.variable.parameter.url {

--- a/styles/languages/scss.less
+++ b/styles/languages/scss.less
@@ -17,7 +17,7 @@
       .uno-2();
     }
     .punctuation {
-      .uno-4();
+      .uno-5();
     }
   }
   &.variable.parameter.url {

--- a/styles/languages/slim.less
+++ b/styles/languages/slim.less
@@ -2,10 +2,10 @@
 
 .slim {
   &.meta {
-    .uno-4();
+    .uno-5();
   }
   &.text {
-    .uno-3();
+    .uno-4();
   }
   .string .id {
     .duo-1();

--- a/styles/languages/yaml.less
+++ b/styles/languages/yaml.less
@@ -8,6 +8,6 @@
     .duo-2();
   }
   .punctuation {
-    .uno-4();
+    .uno-5();
   }
 }

--- a/styles/palette.less
+++ b/styles/palette.less
@@ -1,10 +1,11 @@
 
 // DuoTone palette
 
-.uno-1 { color: @uno-1; } // .... Strong
-.uno-2 { color: @uno-2; } // ...   |
-.uno-3 { color: @uno-3; } // ..    v
-.uno-4 { color: @uno-4; } // .    Weak
+.uno-1 { color: @uno-1; } // ..... Strong
+.uno-2 { color: @uno-2; } // ....   |
+.uno-3 { color: @uno-3; } // ...    |
+.uno-4 { color: @uno-4; } // ..     |
+.uno-5 { color: @uno-5; } // .    Weak
 
 .duo-1 { color: @duo-1; } // .... Strong
 .duo-2 { color: @duo-2; } // ...   |

--- a/styles/palette.less
+++ b/styles/palette.less
@@ -1,0 +1,11 @@
+
+// DuoTone palette
+
+.uno-1 { color: @uno-1; } // .... Strong
+.uno-2 { color: @uno-2; } // ...   |
+.uno-3 { color: @uno-3; } // ..    v
+.uno-4 { color: @uno-4; } // .    Weak
+
+.duo-1 { color: @duo-1; } // .... Strong
+.duo-2 { color: @duo-2; } // ...   |
+.duo-3 { color: @duo-3; } // .    Weak


### PR DESCRIPTION
- uses 8 hues (instead of 7)
- moves the color mixins into a `palette.less` file. This allows other DuoTone themes to import the `/styles/languages/` as a dependency.
