### PR TITLE
Stop coloring .meta

### DIFF
--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -15,12 +15,6 @@
 
 // Uno hue -----------------------------------
 
-// this basically matches everything without a specific scope
-// so we put it first
-.meta {
-  .uno-5();
-}
-
 .html.elements,
 .entity,
 .tag,

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,4 +1,7 @@
 .js {
+  &.delimiter {
+    .uno-5();
+  }
   &.source {
     .uno-2();
     .punctuation-mixin();


### PR DESCRIPTION
This removes the styling of `.meta`. It doesn't seem to be needed anymore. There is a small fix for JS.

Closes #17